### PR TITLE
feat: Improve quiz results and fix blank questions

### DIFF
--- a/memento/Services/QuizQuestionService.swift
+++ b/memento/Services/QuizQuestionService.swift
@@ -131,25 +131,26 @@ class QuizQuestionService: ObservableObject {
         ))
         
         // Fill blank question
-        let example = idiom.examples.first ?? Example(english: "", japanese: "", tone: "casual")
-        let blankedText = example.english.replacingOccurrences(of: idiom.title, with: "_____")
-        
-        let fillBlankQuestion = languageService.isJapanese ? 
-            "空欄を埋めてください：\(blankedText)" : 
-            "Fill in the blank: \(blankedText)"
-        
-        let fillBlankCorrectAnswer = idiom.title
-        let fillBlankDistractors = generateFillBlankDistractors(for: idiom, languageService: languageService)
-        
-        let fillBlankOptions = ([fillBlankCorrectAnswer] + fillBlankDistractors).shuffled()
-        let fillBlankCorrectIndex = fillBlankOptions.firstIndex(of: fillBlankCorrectAnswer) ?? 0
-        
-        questions.append(IdiomQuizQuestion(
-            question: fillBlankQuestion,
-            options: fillBlankOptions,
-            correctAnswer: fillBlankCorrectIndex,
-            type: .fillBlank
-        ))
+        if let example = idiom.examples.first, !example.english.isEmpty {
+            let blankedText = example.english.replacingOccurrences(of: idiom.title, with: "_____")
+
+            let fillBlankQuestion = languageService.isJapanese ?
+                "空欄を埋めてください：\(blankedText)" :
+                "Fill in the blank: \(blankedText)"
+
+            let fillBlankCorrectAnswer = idiom.title
+            let fillBlankDistractors = generateFillBlankDistractors(for: idiom, languageService: languageService)
+
+            let fillBlankOptions = ([fillBlankCorrectAnswer] + fillBlankDistractors).shuffled()
+            let fillBlankCorrectIndex = fillBlankOptions.firstIndex(of: fillBlankCorrectAnswer) ?? 0
+
+            questions.append(IdiomQuizQuestion(
+                question: fillBlankQuestion,
+                options: fillBlankOptions,
+                correctAnswer: fillBlankCorrectIndex,
+                type: .fillBlank
+            ))
+        }
         
         // Context question
         let contextQuestion = languageService.isJapanese ? 

--- a/memento/Views/Components/ConfettiCannon.swift
+++ b/memento/Views/Components/ConfettiCannon.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct ConfettiCannon: ViewModifier {
+    @Binding var isAnimating: Bool
+    let amount: Int
+    let duration: TimeInterval
+
+    func body(content: Content) -> some View {
+        content
+            .overlay(
+                ZStack {
+                    if isAnimating {
+                        ForEach(0..<amount, id: \.self) { _ in
+                            ConfettiPiece(isAnimating: $isAnimating, duration: duration)
+                        }
+                    }
+                }
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                        isAnimating = false
+                    }
+                }
+            )
+    }
+}
+
+struct ConfettiPiece: View {
+    @Binding var isAnimating: Bool
+    let duration: TimeInterval
+
+    @State private var x: CGFloat = .random(in: -0.5...0.5)
+    @State private var y: CGFloat = .random(in: -0.5...0.5)
+    @State private var rotation: Angle = .degrees(.random(in: 0...360))
+    @State private var scale: CGFloat = .random(in: 0.5...1.5)
+    @State private var opacity: Double = 1.0
+
+    private let color: Color = [.red, .green, .blue, .yellow, .purple, .orange].randomElement()!
+
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(width: 10, height: 10)
+            .scaleEffect(scale)
+            .rotationEffect(rotation)
+            .offset(x: x * 500, y: y * 500)
+            .opacity(opacity)
+            .onAppear {
+                withAnimation(.linear(duration: duration)) {
+                    opacity = 0
+                }
+            }
+    }
+}
+
+extension View {
+    func confettiCannon(isAnimating: Binding<Bool>, amount: Int = 100, duration: TimeInterval = 3.0) -> some View {
+        self.modifier(ConfettiCannon(isAnimating: isAnimating, amount: amount, duration: duration))
+    }
+}

--- a/memento/Views/IdiomQuizView.swift
+++ b/memento/Views/IdiomQuizView.swift
@@ -370,6 +370,7 @@ struct IdiomQuizResultsView: View {
     let onFinish: () -> Void
     @EnvironmentObject private var languageService: LanguageService
     @EnvironmentObject private var userProgressService: UserProgressService
+    @State private var showConfetti = false
     
     private var percentage: Double {
         guard totalQuestions > 0 else { return 0 }
@@ -379,8 +380,10 @@ struct IdiomQuizResultsView: View {
     private var message: String {
         if languageService.isJapanese {
             switch percentage {
-            case 80...100:
-                return "素晴らしい！完璧です！"
+            case 100:
+                return "完璧です！素晴らしい！"
+            case 80..<100:
+                return "素晴らしい！"
             case 60..<80:
                 return "よくできました！"
             case 40..<60:
@@ -390,8 +393,10 @@ struct IdiomQuizResultsView: View {
             }
         } else {
             switch percentage {
-            case 80...100:
-                return "Excellent! Perfect score!"
+            case 100:
+                return "Perfect score! Absolutely brilliant!"
+            case 80..<100:
+                return "Excellent!"
             case 60..<80:
                 return "Well done!"
             case 40..<60:
@@ -409,14 +414,14 @@ struct IdiomQuizResultsView: View {
     var body: some View {
         VStack(spacing: 24) {
             // Result icon
-            Image(systemName: percentage >= 60 ? "star.fill" : "star")
+            Image(systemName: percentage == 100 ? "crown.fill" : (percentage >= 60 ? "star.fill" : "star"))
                 .font(.system(size: 64))
-                .foregroundColor(percentage >= 60 ? .yellow : .gray)
-            
+                .foregroundColor(percentage == 100 ? .yellow : (percentage >= 60 ? .yellow : .gray))
+
             // Score display
             VStack(spacing: 8) {
-                Text(languageService.isJapanese ? 
-                     "\(score)/\(totalQuestions) 正解" : 
+                Text(languageService.isJapanese ?
+                     "\(score)/\(totalQuestions) 正解" :
                      "\(score)/\(totalQuestions) correct")
                     .font(.title2)
                     .fontWeight(.semibold)
@@ -437,8 +442,8 @@ struct IdiomQuizResultsView: View {
                 HStack {
                     Image(systemName: "trophy.fill")
                         .foregroundColor(.yellow)
-                    Text(languageService.isJapanese ? 
-                         "新しい記録！" : 
+                    Text(languageService.isJapanese ?
+                         "新しい記録！" :
                          "New record!")
                         .font(.subheadline)
                         .fontWeight(.semibold)
@@ -467,11 +472,15 @@ struct IdiomQuizResultsView: View {
         }
         .padding()
         .onAppear {
+            if percentage == 100 {
+                showConfetti = true
+            }
             // Record that this idiom has been learned if the user passed the quiz (60% or higher)
             if percentage >= 60 {
                 userProgressService.recordLearnedIdiom(idiom.id)
             }
         }
+        .confettiCannon(isAnimating: $showConfetti)
     }
 }
 


### PR DESCRIPTION
This commit introduces two main improvements to the quiz feature:

1.  **100% Score Celebration:** A special celebration has been added for users who achieve a perfect score on a quiz. This includes a unique message, a crown icon, and a confetti animation to make the achievement more rewarding.

2.  **Blank Question Fix:** A bug that caused blank fill-in-the-blank questions to be displayed in quizzes has been fixed. The quiz generation logic now ensures that these questions are only created for idioms that have at least one example sentence, preventing the issue from occurring.